### PR TITLE
Improve GitHub Pages deployment to exclude CMS and dev files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,15 @@ jobs:
       - name: Build site
         run: bun run build
 
+      - name: Create deployment directory
+        run: |
+          mkdir -p _site
+          rsync -av --exclude='cms' --exclude='src' --exclude='scripts' --exclude='.github' --exclude='node_modules' --exclude='.claude' --exclude='.cms-backups' --exclude='*.tmp' --exclude='package.json' --exclude='bun.lockb' --exclude='tsconfig.json' --exclude='.gitignore' ./ _site/
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
+          path: '_site'
 
   deploy:
     environment:


### PR DESCRIPTION
- Add .nojekyll file to prevent Jekyll processing
- Update workflow to copy only production files to _site directory
- Exclude: cms/, src/, scripts/, node_modules, dev configs
- Ensures CMS remains local-only and not publicly accessible