### PR TITLE
Add talk, presentation, and podcast subtypes for durational content

### DIFF
--- a/cms/public/js/cms.js
+++ b/cms/public/js/cms.js
@@ -596,6 +596,9 @@ async function showEditForm(node, essayContent = '') {
           <option value="dj-mix" ${node.subtype === 'dj-mix' ? 'selected' : ''}>DJ Mix</option>
           <option value="piece" ${node.subtype === 'piece' ? 'selected' : ''}>Piece</option>
           <option value="performance" ${node.subtype === 'performance' ? 'selected' : ''}>Performance</option>
+          <option value="talk" ${node.subtype === 'talk' ? 'selected' : ''}>Talk</option>
+          <option value="presentation" ${node.subtype === 'presentation' ? 'selected' : ''}>Presentation</option>
+          <option value="podcast" ${node.subtype === 'podcast' ? 'selected' : ''}>Podcast</option>
         </select>
       </div>
 

--- a/cms/server/services/validation.ts
+++ b/cms/server/services/validation.ts
@@ -156,8 +156,8 @@ export function validateDurationalData(data: Partial<DurationalData>): Validatio
     errors.push('Type must be "durational"');
   }
 
-  if (data.subtype && !['dj-mix', 'talk', 'podcast'].includes(data.subtype)) {
-    errors.push('Invalid subtype (must be dj-mix, talk, or podcast)');
+  if (data.subtype && !['dj-mix', 'talk', 'podcast', 'presentation'].includes(data.subtype)) {
+    errors.push('Invalid subtype (must be dj-mix, talk, podcast, or presentation)');
   }
 
   if (!data.media) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,8 +55,8 @@ export interface CuriosityData {
   visible_on_landing?: boolean;
 }
 
-// Durational content data (DJ mixes, talks, podcasts)
-export type DurationalSubtype = 'dj-mix' | 'talk' | 'podcast';
+// Durational content data (DJ mixes, talks, podcasts, presentations)
+export type DurationalSubtype = 'dj-mix' | 'talk' | 'podcast' | 'presentation';
 export type MediaSource = 'soundcloud' | 'mixcloud' | 'youtube' | 'vimeo';
 
 export interface DurationalMedia {


### PR DESCRIPTION
Expands the available subtypes for durational content to include all validated options: dj-mix, piece, performance, talk, presentation, and podcast.

Changes:
- src/types/index.ts: Added presentation to DurationalSubtype type
- cms/server/services/validation.ts: Updated validation to accept new subtypes
- cms/public/js/cms.js: Added Talk, Presentation, and Podcast to dropdown

All subtype values are properly applied to content shown on landing page nodes.